### PR TITLE
Add an is_mod tag to mod directories

### DIFF
--- a/grug.c
+++ b/grug.c
@@ -1,5 +1,5 @@
 // NOTE: DON'T EDIT THIS FILE! IT IS AUTOMATICALLY REGENERATED BASED ON THE FILES IN src/
-// Regenerated on 2025-08-18T02:41:27Z
+// Regenerated on 2025-08-18T15:45:40Z
 
 //// GRUG DOCUMENTATION
 //
@@ -9472,8 +9472,12 @@ static void reload_modified_mod(const char *mods_dir_path, const char *dll_dir_p
 	directory_depth--;
 }
 
-static void validate_about_file(const char *about_json_path) {
-	grug_assert(access(about_json_path, F_OK) == 0, "Every mod requires an 'about.json' file, but the mod '%s' doesn't have one", mod);
+static bool validate_about_file(const char *about_json_path) {
+  // returns false if the about file dosent exist, raises a grug error if the about.json is invalid
+	if (access(about_json_path, F_OK)) {
+  	errno = 0;
+  	return false;
+	}
 
 	struct json_node node;
 	json(about_json_path, &node);
@@ -9509,6 +9513,8 @@ static void validate_about_file(const char *about_json_path) {
 		grug_assert(!streq(field->key, ""), "%s its %zuth field key must not be an empty string", about_json_path, i + 1);
 		field++;
 	}
+
+	return true;
 }
 
 // Cases:
@@ -9522,11 +9528,20 @@ static const char *get_basename(const char *path) {
 	return base ? base + 1 : path;
 }
 
-static void reload_modified_mods(void) {
-	struct grug_mod_dir *dir = &grug_mods;
+static char entry_path[STUPID_MAX_PATH];
+static char dll_entry_path[STUPID_MAX_PATH];
 
-	DIR *dirp = opendir(mods_root_dir_path);
-	grug_assert(dirp, "opendir(\"%s\"): %s", mods_root_dir_path, strerror(errno));
+static void reload_modified_mods_dir(char *mods_root_path, char *dll_root_path, struct grug_mod_dir *dir) {
+  if (mods_root_path != entry_path) { // this is a pointer comparison, sets up entry_path if needed
+    grug_assert(snprintf(entry_path, sizeof(entry_path), "%s", mods_root_path) >= 0, "Filling the variable 'entry_path' failed");
+  }
+
+  if (dll_root_path != dll_entry_path) { // this is a pointer comparison, sets up entry_path if needed
+    grug_assert(snprintf(dll_entry_path, sizeof(dll_entry_path), "%s", dll_root_path) >= 0, "Filling the variable 'entry_path' failed");
+  }
+
+	DIR *dirp = opendir(mods_root_path);
+	grug_assert(dirp, "opendir(\"%s\"): %s", mods_root_path, strerror(errno));
 
 	for (size_t i = 0; i < dir->dirs_size; i++) {
 		dir->dirs[i]._seen = false;
@@ -9541,38 +9556,49 @@ static void reload_modified_mods(void) {
 			continue;
 		}
 
-		static char entry_path[STUPID_MAX_PATH];
-		grug_assert(snprintf(entry_path, sizeof(entry_path), "%s/%s", mods_root_dir_path, name) >= 0, "Filling the variable 'entry_path' failed");
+		int entry_start = strlen(entry_path);
+		grug_assert(snprintf(&entry_path[entry_start], sizeof(entry_path) - entry_start, "/%s", name) >= 0, "Filling the variable 'entry_path' failed");
 
 		struct stat entry_stat;
 		grug_assert(stat(entry_path, &entry_stat) == 0, "stat: %s: %s", entry_path, strerror(errno));
 
-		if (S_ISDIR(entry_stat.st_mode)) {
-			mod = name;
+		int dll_entry_start = strlen(dll_entry_path);
+		grug_assert(snprintf(&dll_entry_path[dll_entry_start], sizeof(dll_entry_path) - dll_entry_start, "/%s", name) >= 0, "Filling the variable 'entry_path' failed");
 
+		if (S_ISDIR(entry_stat.st_mode)) {
 			static char about_json_path[STUPID_MAX_PATH];
 			grug_assert(snprintf(about_json_path, sizeof(about_json_path), "%s/about.json", entry_path) >= 0, "Filling the variable 'about_json_path' failed");
 
-			validate_about_file(about_json_path);
+ 			// This always returns NULL during the first call of reload_modified_mods()
+ 			struct grug_mod_dir *subdir = get_subdir(dir, name);
 
-			static char dll_entry_path[STUPID_MAX_PATH];
-			grug_assert(snprintf(dll_entry_path, sizeof(dll_entry_path), "%s/%s", dll_root_dir_path, name) >= 0, "Filling the variable 'dll_entry_path' failed");
+ 			if (!subdir) {
+  			struct grug_mod_dir inserted_subdir = { .name = strdup(entry_path) };
+  			grug_assert(inserted_subdir.name, "strdup: %s", strerror(errno));
+  			subdir = push_subdir(dir, inserted_subdir);
+ 			}
 
-			// This always returns NULL during the first call of reload_modified_mods()
-			struct grug_mod_dir *subdir = get_subdir(dir, name);
+			if ((subdir->is_mod = validate_about_file(about_json_path))) {
+			  mod = name;
 
-			if (!subdir) {
-				struct grug_mod_dir inserted_subdir = {.name = strdup(name)};
-				grug_assert(inserted_subdir.name, "strdup: %s", strerror(errno));
-				subdir = push_subdir(dir, inserted_subdir);
+   			subdir->_seen = true;
+   			reload_modified_mod(entry_path, dll_entry_path, subdir);
+			} else {
+   			subdir->_seen = true;
+			  reload_modified_mods_dir(entry_path, dll_entry_path, subdir);
 			}
 
-			subdir->_seen = true;
-
-			reload_modified_mod(entry_path, dll_entry_path, subdir);
-			assert(directory_depth == 0);
+      if (!subdir->is_mod) {
+        grug_assert(subdir->files_size == 0, "Grug files must be contained in a valid mod directory, however no parent of '%s' has an about.json", entry_path)
+      }
+		} else if (S_ISREG(entry_stat.st_mode)) {
+		  grug_assert(!streq(get_file_extension(entry_path), ".grug"), "Grug files must be contained in a valid mod directory, however no parent of '%s' has an about.json", entry_path)
 		}
+
+		entry_path[entry_start] = 0;
+		dll_entry_path[dll_entry_start] = 0;
 	}
+
 	grug_assert(errno == 0, "readdir: %s", strerror(errno));
 
 	closedir(dirp);
@@ -9585,6 +9611,11 @@ static void reload_modified_mods(void) {
 			dir->dirs[i] = dir->dirs[--dir->dirs_size]; // Swap-remove
 		}
 	}
+}
+
+static void reload_modified_mods(void) {
+  entry_path[0] = 0;
+	reload_modified_mods_dir(mods_root_dir_path, dll_root_dir_path, &grug_mods);
 }
 
 bool grug_init(grug_runtime_error_handler_t handler, const char *mod_api_json_path, const char *mods_dir_path, const char *dll_dir_path, uint64_t on_fn_time_limit_ms_) {
@@ -9686,4 +9717,3 @@ void grug_toggle_on_fns_mode(void) {
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-

--- a/grug.c
+++ b/grug.c
@@ -1,5 +1,5 @@
 // NOTE: DON'T EDIT THIS FILE! IT IS AUTOMATICALLY REGENERATED BASED ON THE FILES IN src/
-// Regenerated on 2025-08-18T15:45:40Z
+// Regenerated on 2025-08-18T18:41:57Z
 
 //// GRUG DOCUMENTATION
 //
@@ -9475,8 +9475,10 @@ static void reload_modified_mod(const char *mods_dir_path, const char *dll_dir_p
 static bool validate_about_file(const char *about_json_path) {
   // returns false if the about file dosent exist, raises a grug error if the about.json is invalid
 	if (access(about_json_path, F_OK)) {
-  	errno = 0;
-  	return false;
+		grug_assert(errno == ENOENT, "failed to open 'about.json' for mod '%s': '%s'", about_json_path, strerror(errno));
+		errno = 0;
+
+		return false;
 	}
 
 	struct json_node node;
@@ -9528,17 +9530,18 @@ static const char *get_basename(const char *path) {
 	return base ? base + 1 : path;
 }
 
-static char entry_path[STUPID_MAX_PATH];
-static char dll_entry_path[STUPID_MAX_PATH];
-
 static void reload_modified_mods_dir(char *mods_root_path, char *dll_root_path, struct grug_mod_dir *dir) {
-  if (mods_root_path != entry_path) { // this is a pointer comparison, sets up entry_path if needed
-    grug_assert(snprintf(entry_path, sizeof(entry_path), "%s", mods_root_path) >= 0, "Filling the variable 'entry_path' failed");
-  }
+	// This is an indented pointer comparison, which sets up entry_path if needed.
+	static char entry_path[STUPID_MAX_PATH];
+	if (mods_root_path != entry_path) {
+		grug_assert(snprintf(entry_path, sizeof(entry_path), "%s", mods_root_path) >= 0, "Filling the variable 'entry_path' failed");
+	}
 
-  if (dll_root_path != dll_entry_path) { // this is a pointer comparison, sets up entry_path if needed
-    grug_assert(snprintf(dll_entry_path, sizeof(dll_entry_path), "%s", dll_root_path) >= 0, "Filling the variable 'entry_path' failed");
-  }
+	// This is an indented pointer comparison, which sets up entry_path if needed.
+	static char dll_entry_path[STUPID_MAX_PATH];
+	if (dll_root_path != dll_entry_path) {
+		grug_assert(snprintf(dll_entry_path, sizeof(dll_entry_path), "%s", dll_root_path) >= 0, "Filling the variable 'entry_path' failed");
+	}
 
 	DIR *dirp = opendir(mods_root_path);
 	grug_assert(dirp, "opendir(\"%s\"): %s", mods_root_path, strerror(errno));
@@ -9556,47 +9559,47 @@ static void reload_modified_mods_dir(char *mods_root_path, char *dll_root_path, 
 			continue;
 		}
 
-		int entry_start = strlen(entry_path);
+		size_t entry_start = strlen(entry_path);
 		grug_assert(snprintf(&entry_path[entry_start], sizeof(entry_path) - entry_start, "/%s", name) >= 0, "Filling the variable 'entry_path' failed");
+
+		size_t dll_entry_start = strlen(dll_entry_path);
+		grug_assert(snprintf(&dll_entry_path[dll_entry_start], sizeof(dll_entry_path) - dll_entry_start, "/%s", name) >= 0, "Filling the variable 'entry_path' failed");
 
 		struct stat entry_stat;
 		grug_assert(stat(entry_path, &entry_stat) == 0, "stat: %s: %s", entry_path, strerror(errno));
-
-		int dll_entry_start = strlen(dll_entry_path);
-		grug_assert(snprintf(&dll_entry_path[dll_entry_start], sizeof(dll_entry_path) - dll_entry_start, "/%s", name) >= 0, "Filling the variable 'entry_path' failed");
 
 		if (S_ISDIR(entry_stat.st_mode)) {
 			static char about_json_path[STUPID_MAX_PATH];
 			grug_assert(snprintf(about_json_path, sizeof(about_json_path), "%s/about.json", entry_path) >= 0, "Filling the variable 'about_json_path' failed");
 
- 			// This always returns NULL during the first call of reload_modified_mods()
- 			struct grug_mod_dir *subdir = get_subdir(dir, name);
+			// This always returns NULL during the first calls of reload_modified_mods_dir()
+			struct grug_mod_dir *subdir = get_subdir(dir, name);
 
- 			if (!subdir) {
-  			struct grug_mod_dir inserted_subdir = { .name = strdup(entry_path) };
-  			grug_assert(inserted_subdir.name, "strdup: %s", strerror(errno));
-  			subdir = push_subdir(dir, inserted_subdir);
- 			}
-
-			if ((subdir->is_mod = validate_about_file(about_json_path))) {
-			  mod = name;
-
-   			subdir->_seen = true;
-   			reload_modified_mod(entry_path, dll_entry_path, subdir);
-			} else {
-   			subdir->_seen = true;
-			  reload_modified_mods_dir(entry_path, dll_entry_path, subdir);
+			if (!subdir) {
+				struct grug_mod_dir inserted_subdir = { .name = strdup(name) };
+				grug_assert(inserted_subdir.name, "strdup: %s", strerror(errno));
+				subdir = push_subdir(dir, inserted_subdir);
 			}
 
-      if (!subdir->is_mod) {
-        grug_assert(subdir->files_size == 0, "Grug files must be contained in a valid mod directory, however no parent of '%s' has an about.json", entry_path)
-      }
+			if ((subdir->is_mod = validate_about_file(about_json_path))) {
+				mod = name;
+
+				subdir->_seen = true;
+				reload_modified_mod(entry_path, dll_entry_path, subdir);
+			} else {
+				subdir->_seen = true;
+				reload_modified_mods_dir(entry_path, dll_entry_path, subdir);
+			}
+
+			if (!subdir->is_mod) {
+				grug_assert(subdir->files_size == 0, "Grug files must be contained in a valid mod directory, however no parent of '%s' has an about.json", entry_path)
+			}
 		} else if (S_ISREG(entry_stat.st_mode)) {
-		  grug_assert(!streq(get_file_extension(entry_path), ".grug"), "Grug files must be contained in a valid mod directory, however no parent of '%s' has an about.json", entry_path)
+			grug_assert(!streq(get_file_extension(entry_path), ".grug"), "Grug files must be contained in a valid mod directory, however no parent of '%s' has an about.json", entry_path)
 		}
 
-		entry_path[entry_start] = 0;
-		dll_entry_path[dll_entry_start] = 0;
+		entry_path[entry_start] = '\x00';
+		dll_entry_path[dll_entry_start] = '\x00';
 	}
 
 	grug_assert(errno == 0, "readdir: %s", strerror(errno));
@@ -9611,11 +9614,6 @@ static void reload_modified_mods_dir(char *mods_root_path, char *dll_root_path, 
 			dir->dirs[i] = dir->dirs[--dir->dirs_size]; // Swap-remove
 		}
 	}
-}
-
-static void reload_modified_mods(void) {
-  entry_path[0] = 0;
-	reload_modified_mods_dir(mods_root_dir_path, dll_root_dir_path, &grug_mods);
 }
 
 bool grug_init(grug_runtime_error_handler_t handler, const char *mod_api_json_path, const char *mods_dir_path, const char *dll_dir_path, uint64_t on_fn_time_limit_ms_) {
@@ -9667,7 +9665,7 @@ bool grug_regenerate_modified_mods(void) {
 		grug_assert(grug_mods.name, "strdup: %s", strerror(errno));
 	}
 
-	reload_modified_mods();
+	reload_modified_mods_dir(mods_root_dir_path, dll_root_dir_path, &grug_mods);
 
 	check_that_every_entity_exists(grug_mods);
 

--- a/grug.h
+++ b/grug.h
@@ -98,6 +98,7 @@ struct grug_mod_dir {
 	size_t files_size;
 	size_t _files_capacity;
 
+	bool is_mod;
 	bool _seen;
 };
 

--- a/src/15_hot_reloading.c
+++ b/src/15_hot_reloading.c
@@ -633,8 +633,12 @@ static void reload_modified_mod(const char *mods_dir_path, const char *dll_dir_p
 	directory_depth--;
 }
 
-static void validate_about_file(const char *about_json_path) {
-	grug_assert(access(about_json_path, F_OK) == 0, "Every mod requires an 'about.json' file, but the mod '%s' doesn't have one", mod);
+static bool validate_about_file(const char *about_json_path) {
+  // returns false if the about file dosent exist, raises a grug error if the about.json is invalid
+	if (access(about_json_path, F_OK)) {
+  	errno = 0;
+  	return false;
+	}
 
 	struct json_node node;
 	json(about_json_path, &node);
@@ -670,6 +674,8 @@ static void validate_about_file(const char *about_json_path) {
 		grug_assert(!streq(field->key, ""), "%s its %zuth field key must not be an empty string", about_json_path, i + 1);
 		field++;
 	}
+
+	return true;
 }
 
 // Cases:
@@ -683,11 +689,20 @@ static const char *get_basename(const char *path) {
 	return base ? base + 1 : path;
 }
 
-static void reload_modified_mods(void) {
-	struct grug_mod_dir *dir = &grug_mods;
+static char entry_path[STUPID_MAX_PATH];
+static char dll_entry_path[STUPID_MAX_PATH];
 
-	DIR *dirp = opendir(mods_root_dir_path);
-	grug_assert(dirp, "opendir(\"%s\"): %s", mods_root_dir_path, strerror(errno));
+static void reload_modified_mods_dir(char *mods_root_path, char *dll_root_path, struct grug_mod_dir *dir) {
+  if (mods_root_path != entry_path) { // this is a pointer comparison, sets up entry_path if needed
+    grug_assert(snprintf(entry_path, sizeof(entry_path), "%s", mods_root_path) >= 0, "Filling the variable 'entry_path' failed");
+  }
+
+  if (dll_root_path != dll_entry_path) { // this is a pointer comparison, sets up entry_path if needed
+    grug_assert(snprintf(dll_entry_path, sizeof(dll_entry_path), "%s", dll_root_path) >= 0, "Filling the variable 'entry_path' failed");
+  }
+
+	DIR *dirp = opendir(mods_root_path);
+	grug_assert(dirp, "opendir(\"%s\"): %s", mods_root_path, strerror(errno));
 
 	for (size_t i = 0; i < dir->dirs_size; i++) {
 		dir->dirs[i]._seen = false;
@@ -702,38 +717,49 @@ static void reload_modified_mods(void) {
 			continue;
 		}
 
-		static char entry_path[STUPID_MAX_PATH];
-		grug_assert(snprintf(entry_path, sizeof(entry_path), "%s/%s", mods_root_dir_path, name) >= 0, "Filling the variable 'entry_path' failed");
+		int entry_start = strlen(entry_path);
+		grug_assert(snprintf(&entry_path[entry_start], sizeof(entry_path) - entry_start, "/%s", name) >= 0, "Filling the variable 'entry_path' failed");
 
 		struct stat entry_stat;
 		grug_assert(stat(entry_path, &entry_stat) == 0, "stat: %s: %s", entry_path, strerror(errno));
 
-		if (S_ISDIR(entry_stat.st_mode)) {
-			mod = name;
+		int dll_entry_start = strlen(dll_entry_path);
+		grug_assert(snprintf(&dll_entry_path[dll_entry_start], sizeof(dll_entry_path) - dll_entry_start, "/%s", name) >= 0, "Filling the variable 'entry_path' failed");
 
+		if (S_ISDIR(entry_stat.st_mode)) {
 			static char about_json_path[STUPID_MAX_PATH];
 			grug_assert(snprintf(about_json_path, sizeof(about_json_path), "%s/about.json", entry_path) >= 0, "Filling the variable 'about_json_path' failed");
 
-			validate_about_file(about_json_path);
+ 			// This always returns NULL during the first call of reload_modified_mods()
+ 			struct grug_mod_dir *subdir = get_subdir(dir, name);
 
-			static char dll_entry_path[STUPID_MAX_PATH];
-			grug_assert(snprintf(dll_entry_path, sizeof(dll_entry_path), "%s/%s", dll_root_dir_path, name) >= 0, "Filling the variable 'dll_entry_path' failed");
+ 			if (!subdir) {
+  			struct grug_mod_dir inserted_subdir = { .name = strdup(entry_path) };
+  			grug_assert(inserted_subdir.name, "strdup: %s", strerror(errno));
+  			subdir = push_subdir(dir, inserted_subdir);
+ 			}
 
-			// This always returns NULL during the first call of reload_modified_mods()
-			struct grug_mod_dir *subdir = get_subdir(dir, name);
+			if ((subdir->is_mod = validate_about_file(about_json_path))) {
+			  mod = name;
 
-			if (!subdir) {
-				struct grug_mod_dir inserted_subdir = {.name = strdup(name)};
-				grug_assert(inserted_subdir.name, "strdup: %s", strerror(errno));
-				subdir = push_subdir(dir, inserted_subdir);
+   			subdir->_seen = true;
+   			reload_modified_mod(entry_path, dll_entry_path, subdir);
+			} else {
+   			subdir->_seen = true;
+			  reload_modified_mods_dir(entry_path, dll_entry_path, subdir);
 			}
 
-			subdir->_seen = true;
-
-			reload_modified_mod(entry_path, dll_entry_path, subdir);
-			assert(directory_depth == 0);
+      if (!subdir->is_mod) {
+        grug_assert(subdir->files_size == 0, "Grug files must be contained in a valid mod directory, however no parent of '%s' has an about.json", entry_path)
+      }
+		} else if (S_ISREG(entry_stat.st_mode)) {
+		  grug_assert(!streq(get_file_extension(entry_path), ".grug"), "Grug files must be contained in a valid mod directory, however no parent of '%s' has an about.json", entry_path)
 		}
+
+		entry_path[entry_start] = 0;
+		dll_entry_path[dll_entry_start] = 0;
 	}
+
 	grug_assert(errno == 0, "readdir: %s", strerror(errno));
 
 	closedir(dirp);
@@ -746,6 +772,11 @@ static void reload_modified_mods(void) {
 			dir->dirs[i] = dir->dirs[--dir->dirs_size]; // Swap-remove
 		}
 	}
+}
+
+static void reload_modified_mods(void) {
+  entry_path[0] = 0;
+	reload_modified_mods_dir(mods_root_dir_path, dll_root_dir_path, &grug_mods);
 }
 
 bool grug_init(grug_runtime_error_handler_t handler, const char *mod_api_json_path, const char *mods_dir_path, const char *dll_dir_path, uint64_t on_fn_time_limit_ms_) {


### PR DESCRIPTION
Implements #12, functionally works the same, but the user can check the is_mod field in a mod dir if they want to make a mod explorer menu, currently grug will raise an error if a .grug file is located outside of a mod.