### PR TITLE
Implements #25 (Disabled mods)

### DIFF
--- a/grug.c
+++ b/grug.c
@@ -1,5 +1,5 @@
 // NOTE: DON'T EDIT THIS FILE! IT IS AUTOMATICALLY REGENERATED BASED ON THE FILES IN src/
-// Regenerated on 2025-08-23T21:32:57Z
+// Regenerated on 2025-08-23T22:40:32Z
 
 //// GRUG DOCUMENTATION
 //
@@ -9441,7 +9441,6 @@ static void reload_modified_mod(const char *mods_dir_path, const char *dll_dir_p
 	for (size_t i = 0; i < dir->files_size; i++) {
 		dir->files[i]._seen = false;
 	}
-			
 
 	errno = 0;
 	struct dirent *dp;

--- a/grug.c
+++ b/grug.c
@@ -1,5 +1,5 @@
 // NOTE: DON'T EDIT THIS FILE! IT IS AUTOMATICALLY REGENERATED BASED ON THE FILES IN src/
-// Regenerated on 2025-08-18T02:41:27Z
+// Regenerated on 2025-08-23T21:32:57Z
 
 //// GRUG DOCUMENTATION
 //
@@ -9441,11 +9441,13 @@ static void reload_modified_mod(const char *mods_dir_path, const char *dll_dir_p
 	for (size_t i = 0; i < dir->files_size; i++) {
 		dir->files[i]._seen = false;
 	}
+			
 
 	errno = 0;
 	struct dirent *dp;
 	while ((dp = readdir(dirp))) {
-		reload_entry(dp->d_name, mods_dir_path, dll_dir_path, dir);
+		if (!dir->_disabled)
+			reload_entry(dp->d_name, mods_dir_path, dll_dir_path, dir);
 	}
 	grug_assert(errno == 0, "readdir: %s", strerror(errno));
 
@@ -9665,6 +9667,17 @@ void grug_toggle_on_fns_mode(void) {
 	grug_on_fns_in_safe_mode = !grug_on_fns_in_safe_mode;
 }
 
+void grug_set_mod_dir_enabled(struct grug_mod_dir *mod) {
+	mod->_disabled = false;
+}
+
+void grug_set_mod_dir_disabled(struct grug_mod_dir *mod) {
+	mod->_disabled = true;
+}
+
+bool grug_is_mod_dir_enabled(const struct grug_mod_dir *mod) {
+	return !mod->_disabled;	
+}
 // MIT License
 
 // Copyright (c) 2024 MyNameIsTrez
@@ -9686,4 +9699,3 @@ void grug_toggle_on_fns_mode(void) {
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-

--- a/grug.h
+++ b/grug.h
@@ -24,6 +24,8 @@ typedef void (*grug_runtime_error_handler_t)(const char *reason, enum grug_runti
 
 typedef void (*grug_init_globals_fn_t)(void *globals, uint64_t id);
 
+struct grug_mod_dir;
+
 //// Functions
 
 // Returns whether an error occurred
@@ -62,6 +64,13 @@ void grug_set_on_fns_to_fast_mode(void);
 bool grug_are_on_fns_in_safe_mode(void) __attribute__((warn_unused_result));
 void grug_toggle_on_fns_mode(void);
 
+// Enable and disable mods
+// changes with these are applied on the next call to grug_regenerate_modified_mods
+// Please note this includes all loading and reloading of mods.
+void grug_set_mod_dir_enabled(struct grug_mod_dir *mod);
+void grug_set_mod_dir_disabled(struct grug_mod_dir *mod);
+bool grug_is_mod_dir_enabled(const struct grug_mod_dir *mod) __attribute__((warn_unused_result));
+
 //// Defines
 
 #define MAX_RELOADS 6969
@@ -98,6 +107,7 @@ struct grug_mod_dir {
 	size_t files_size;
 	size_t _files_capacity;
 
+	bool _disabled;
 	bool _seen;
 };
 

--- a/src/15_hot_reloading.c
+++ b/src/15_hot_reloading.c
@@ -602,7 +602,6 @@ static void reload_modified_mod(const char *mods_dir_path, const char *dll_dir_p
 	for (size_t i = 0; i < dir->files_size; i++) {
 		dir->files[i]._seen = false;
 	}
-			
 
 	errno = 0;
 	struct dirent *dp;

--- a/src/15_hot_reloading.c
+++ b/src/15_hot_reloading.c
@@ -602,11 +602,13 @@ static void reload_modified_mod(const char *mods_dir_path, const char *dll_dir_p
 	for (size_t i = 0; i < dir->files_size; i++) {
 		dir->files[i]._seen = false;
 	}
+			
 
 	errno = 0;
 	struct dirent *dp;
 	while ((dp = readdir(dirp))) {
-		reload_entry(dp->d_name, mods_dir_path, dll_dir_path, dir);
+		if (!dir->_disabled)
+			reload_entry(dp->d_name, mods_dir_path, dll_dir_path, dir);
 	}
 	grug_assert(errno == 0, "readdir: %s", strerror(errno));
 
@@ -824,4 +826,16 @@ bool grug_are_on_fns_in_safe_mode(void) {
 }
 void grug_toggle_on_fns_mode(void) {
 	grug_on_fns_in_safe_mode = !grug_on_fns_in_safe_mode;
+}
+
+void grug_set_mod_dir_enabled(struct grug_mod_dir *mod) {
+	mod->_disabled = false;
+}
+
+void grug_set_mod_dir_disabled(struct grug_mod_dir *mod) {
+	mod->_disabled = true;
+}
+
+bool grug_is_mod_dir_enabled(const struct grug_mod_dir *mod) {
+	return !mod->_disabled;	
 }


### PR DESCRIPTION
This adds the following functions to manage the enabled state of mods as explained in #25:
```c
void grug_set_mod_dir_enabled(struct grug_mod_dir *mod);
void grug_set_mod_dir_disabled(struct grug_mod_dir *mod);
bool grug_is_mod_dir_enabled(const struct grug_mod_dir *mod) __attribute__((warn_unused_result));
```
none of their effect are immediate and will take effect on the next call to grug_regenerate_modified_mods. In the eyes of the game, the mods will still exist in `grug_mods`, but have 0 child files and 0 child dirs as loading those is completely skipped.

Tried to keep it relatively simple to made sure this will merge cleanly into #47 since that's a confirmed feature.